### PR TITLE
Fix issue with "[]" string not being empty when checking in phtml file

### DIFF
--- a/Block/Order/Repay/PaymentMethods.php
+++ b/Block/Order/Repay/PaymentMethods.php
@@ -156,7 +156,7 @@ class PaymentMethods extends Template
         $this->gatewayConfig->setMethodCode(ConfigProvider::CODE);
         if (!(bool)$this->gatewayConfig->getValue(static::ACTIVE, $storeId) &&
             !(bool)$this->payUConfig->isCrediCardCurrencyRates()) {
-            return json_encode([]);
+            return "";
         }
 
         return json_encode(
@@ -183,7 +183,7 @@ class PaymentMethods extends Template
         $storeId = $this->_storeManager->getStore()->getId();
         $this->gatewayConfig->setMethodCode(CardConfigProvider::CODE);
         if (!(bool)$this->gatewayConfig->getValue(static::ACTIVE, $storeId)) {
-            return json_encode([]);
+            return "";
         }
 
         $userPayMethods = $this->getUserStoredCards();


### PR DESCRIPTION
There is a bug, that inside `view/frontend/templates/order/repay/paymentmethods.phtml` file you are checking if `$config` and `$cardConfig` variables are not empty. The problem is that `json_encode([])` will return "[]" as a string, so it won't return true when calling `empty`.