### PR TITLE
Disable sending email confirmation after placeOrder

### DIFF
--- a/Gateway/Response/OrderCreateResponseHandler.php
+++ b/Gateway/Response/OrderCreateResponseHandler.php
@@ -16,11 +16,16 @@ class OrderCreateResponseHandler implements HandlerInterface
     {
         $paymentDataObject = SubjectReader::readPayment($handlingSubject);
         $payment = $paymentDataObject->getPayment();
+        $order = $payment->getOrder();
 
         $payment
             ->setTransactionId($response['orderId'])
             ->setIsTransactionPending(true)
             ->setIsTransactionClosed(false);
+
+        // No not send order confirmation mail
+        $order
+            ->setCanSendNewEmailFlag(false);
 
         if (array_key_exists(PayUConfigInterface::REDIRECT_URI_FIELD, $response)) {
             $payment->setAdditionalInformation(


### PR DESCRIPTION
When option [Asynchronous sending](https://experienceleague.adobe.com/en/docs/commerce-admin/config/sales/sales-emails) is activated, the order confirmation email is sent before the customer confirms the payment in PayU.

**The fix :** 

Set `setCanSendNewEmailFlag` flag in `OrderCreateResponseHandler`.

---

fixes #31